### PR TITLE
fix: Missing title tag in head #101

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,6 +5,7 @@
     <meta name="description" content="" />
     <link rel="icon" href="%svelte.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Good First Issue Finder</title>
     %svelte.head%
   </head>
   <body>


### PR DESCRIPTION
currently, the site shows the domain name as the title. so I added the title tag in app.html now it will show Good First Issue Finder.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/good-first-issue-finder/pull/113"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

