### PR TITLE
Move the div above the header inside the header

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -7,9 +7,6 @@
 <div class="flex min-h-screen flex-col">
   <div class="float-none mx-auto my-0 w-[90%] max-w-[1400px]">
     <Nav />
-    <div class="mb-8 text-center">
-      Eddiehub Issue-Crawler for finding <b>good-first-issues</b>
-    </div>
     <slot />
   </div>
   <Footer />

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -79,6 +79,9 @@
 </script>
 
 <header class="mb-8 flex flex-col items-center justify-center">
+   <div class="mb-8 text-center">
+      Eddiehub Issue-Crawler for finding <b>good-first-issues</b>
+    </div>
   <div class="mb-4">
     <Toggle
       id="toggle"


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue #102 
This PR Closes #102 
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
The changes in this PR proposes moving the `div` above the `header` containing the text _Eddiehub issue-crawler for finding good first issues_ inside the `header` to improve the semantics of the `HTML` structure
<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [X] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->
![header-fix](https://user-images.githubusercontent.com/2597305/171660290-016f2c32-a5df-4234-ac43-734d22f14392.png)

## Note to reviewers
The above screenshot shows the div which I moved inside the `header` tag. 
Cheers
<!-- Add notes to reviewers if applicable -->

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/good-first-issue-finder/pull/144"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

