### PR TITLE
fix: search cancel css remove

### DIFF
--- a/src/lib/components/search.svelte
+++ b/src/lib/components/search.svelte
@@ -28,3 +28,9 @@
   type="search"
   {placeholder}
 />
+
+<style>
+  input[type='search']::-webkit-search-cancel-button {
+    display: none;
+  }
+</style>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

## Changes proposed
closes #106
<!-- List all the proposed changes in your PR -->
It removes the default cancel style form the search input. That behaves different across browsers.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Note to reviewers
Custome cancel button component can be added afterwards in the search

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/good-first-issue-finder/pull/153"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

