### PR TITLE
feat: seo component #220

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issue-finder",
-  "version": "2.6.1",
+  "version": "2.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "issue-finder",
-      "version": "2.6.1",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "cookie": "^0.5.0",

--- a/src/lib/components/docs/layout.svelte
+++ b/src/lib/components/docs/layout.svelte
@@ -1,9 +1,25 @@
+<!-- script has to be js for mdsvex -->
 <script lang="js">
+  import Seo from '../seo.svelte';
+
   /**
    * @type {string}
    */
   export let title;
+  export let metadescription = 'Documentation for Good First Issue Finder by EddieHub';
+  /**
+   * @type {string}
+   */
+  let seotitle;
+
+  if (title) {
+    seotitle = title + ' | Docs | Good First Issue Finder';
+  } else {
+    seotitle = 'Docs | Good First Issue Finder';
+  }
 </script>
+
+<Seo title={seotitle} {metadescription} />
 
 <div class="prose max-w-none dark:prose-invert">
   <h1>{title}</h1>

--- a/src/lib/components/seo.svelte
+++ b/src/lib/components/seo.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  export let title: string;
+  export let metadescription: string;
+  export let image: { url: string; alt: string } | null = null;
+  export let article = false;
+</script>
+
+<svelte:head>
+  <title>{title}</title>
+  <meta name="description" content={metadescription} />
+  <html lang="en" />
+
+  <!-- OG Tags -->
+  <meta property="og:title" content={title} />
+  <meta property="og:description" content={metadescription} />
+  <meta property="og:locale" content="en_US" />
+  {#if article}
+    <meta property="og:type" content="article" />
+  {/if}
+  {#if image}
+    <meta property="og:image" content={image.url} />
+    <meta property="og:image:alt" content={image.alt} />
+  {/if}
+
+  <!-- Twitter -->
+  <meta name="twitter:title" content={title} />
+  <meta name="twitter:description" content={metadescription} />
+  <meta name="”twitter:card”" content="”summary_large_image”" />
+  {#if image}
+    <meta name="twitter:image" content={image.url} />
+    <meta name="twitter:image:alt" content={image.alt} />
+  {/if}
+</svelte:head>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,8 @@
   import Filter from '$lib/components/filter.svelte';
   import LoadMore from '$lib/components/load-more.svelte';
   import Toggle from '$lib/components/toggle.svelte';
+  import Seo from '$lib/components/seo.svelte';
+
   import { selectedLabels } from '$lib/stores/selected-labels.store';
   import type { SearchResponse } from '../global';
   import { goto } from '$app/navigation';
@@ -65,7 +67,14 @@
   };
 
   $: intersectedArray = filteredLabels.filter((item) => searchItems.includes(item));
+
+  // SEO Parameters
+  const title = 'Good First Issue Finder by EddieHub';
+  const metadescription =
+    'Good First Issue Finder helps new open source contributors pave their path into the world of open source through good first issues.';
 </script>
+
+<Seo {title} {metadescription} />
 
 <div class="my-8 flex flex-col items-center justify-center">
   <div class="mb-4">

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
   import Card from '$lib/components/card.svelte';
+  import Seo from '$lib/components/seo.svelte';
+
+  // SEO Parameters
+  const title = 'Login | Good First Issue Finder';
+  const metadescription =
+    'Good First Issue Finder helps new open source contributors pave their path into the world of open source through good first issues.';
 </script>
+
+<Seo {title} {metadescription} />
 
 <div class="flex w-full items-center justify-center">
   <Card class="flex w-full max-w-md flex-col items-center gap-4">


### PR DESCRIPTION
Working on #220 

## Changes proposed
- [x] SEO Component for Meta, OG and Twitter Tags: title, description, image (+alt)
- [x] Tags for Docs can be set using Frontmatter

## Missing
-  Images
-  Twitter User/Page
-  itemscope/itemprop for LinkedIn


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/good-first-issue-finder/pull/235"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

