### PR TITLE
fix: theme switcher icons centering fixed

### DIFF
--- a/src/lib/components/theme-switcher.svelte
+++ b/src/lib/components/theme-switcher.svelte
@@ -40,7 +40,7 @@
     on:click={setSystem}
     ><i
       class:active={theme === 'system'}
-      class="fa-solid fa-gear text-skin-off mr-1 dark:text-skin-text-highlight"
+      class="fa-solid fa-gear text-skin-off dark:text-skin-text-highlight"
     /></button
   >
   <button
@@ -49,13 +49,13 @@
     on:click={setLight}
     ><i
       class:active={theme === 'light'}
-      class="fa-solid fa-sun text-skin-off mr-1 dark:text-skin-text-highlight"
+      class="fa-solid fa-sun text-skin-off dark:text-skin-text-highlight"
     /></button
   >
   <button class="p-2 text-xs md:p-3 md:text-base" title="Dark Theme" on:click={setDark}
     ><i
       class:active={theme === 'dark'}
-      class="fa-solid fa-moon text-skin-off mr-1 dark:text-skin-text-highlight"
+      class="fa-solid fa-moon text-skin-off dark:text-skin-text-highlight"
     /></button
   >
 </div>


### PR DESCRIPTION
## Fixes Issue
Closes #247 
Removed extra margins to center icons in theme switcher.

## Screenshots

Before:
<img width="138" alt="image" src="https://user-images.githubusercontent.com/33329898/196297737-57705fc9-f508-44c5-917d-c24134dba26d.png">

After:
<img width="138" alt="image" src="https://user-images.githubusercontent.com/33329898/196297711-da1a083d-22d7-48fd-9281-e596245de48c.png">


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/good-first-issue-finder/pull/249"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

