### PR TITLE
Filter out archived repositories from the response

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -9,6 +9,7 @@ export declare type Repository = {
   name: string;
   url: string;
   owner: Owner;
+  isArchived: boolean;
   primaryLanguage: PrimaryLanguage;
   codeOfConduct: CodeOfConduct;
   licenseInfo: LicenseInfo;

--- a/src/routes/api/get-issues/+server.ts
+++ b/src/routes/api/get-issues/+server.ts
@@ -18,7 +18,7 @@ export const POST: RequestHandler = async ({ request }) => {
   const body = (await request.json()) as { query: string; after?: string };
 
   const octokit = new Octokit({ auth: token });
-  const { search }: Response = await octokit.graphql(
+  let { search }: Response = await octokit.graphql(
     `query EddieHubIssues($queryString: String!, $skip: Int!, $after: String) {
   search(first: $skip, query: $queryString, type: ISSUE, after: $after) {
     issueCount
@@ -43,6 +43,7 @@ export const POST: RequestHandler = async ({ request }) => {
           repository {
             name
             url
+            isArchived
             primaryLanguage {
               color
               name
@@ -73,6 +74,10 @@ export const POST: RequestHandler = async ({ request }) => {
       after: body.after,
     },
   );
+
+  // filter out archived (read-only) repositories
+  search = { ...search, edges: search.edges.filter((edge) => !edge.node.repository.isArchived) };
+
   const labels = search.edges.map((el) => el.node.labels.edges.map((label) => label.node.name));
   const merged = labels.reduce((acc, val) => {
     return acc.concat(val);

--- a/src/stories/issue-card.story.svelte
+++ b/src/stories/issue-card.story.svelte
@@ -53,6 +53,7 @@
     repository: {
       name: 'LinkFree',
       url: 'https://github.com/EddieHubCommunity/LinkFree',
+      isArchived: false,
       primaryLanguage: {
         color: '#f1e05a',
         name: 'JavaScript',


### PR DESCRIPTION
## Changes proposed

Archived repositories are read-only and do not accept pull requests, therefore there is no point rendering them on the frontend. This pull request will filter out all the "`isArchived` set to `true`" [repositories](https://docs.github.com/en/graphql/reference/objects#repository) in the response.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation (not required).
- [ ] I have updated the documentation accordingly (not required).
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->


## Note to reviewers

Unable to run the code locally, please test it on your local environment. If it does not contains repositories like [jdogcoderarchives/api](https://github.com/jdogcoderarchives/api), then we are good to go