### PR TITLE
Playwright test to check if the docs header element is active

### DIFF
--- a/tests/docs/introduction.spec.ts
+++ b/tests/docs/introduction.spec.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { expect, test } from '@playwright/test';
 
-test.fixme('docs header element is active', async ({ page }) => {
+test('docs header element is active', async ({ page }) => {
   // navigate to the docs landing page /docs
+  await page.goto('/docs');
   // check if the docs link in the page header is having the active class
+  await expect(page.getByRole('link', { name: 'Docs' })).toHaveClass(/active/);
 });
 
 test('Correct Page Heading', async ({ page }) => {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
I have added a playwright test to check if the docs link is active(has the **_active_** css classname) when the user is on that page (/docs) as shown in the screenshot.
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![image](https://user-images.githubusercontent.com/29143015/214525338-0dd6ff62-6d14-431f-9b4b-0bf880aaa64a.png)