### PR TITLE
add .trim() to searchString

### DIFF
--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -68,7 +68,7 @@
           return true;
         }
         const title = edge.node.title.toLowerCase();
-        return title.includes(searchString.toLowerCase());
+        return title.includes(searchString.trim().toLowerCase());
       });
   });
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
 Closes #356 

## Changes proposed

I have added `trim() ` to `searchString`  which removes the leading and trailing spaces which were earlier being taken into account as a part of actual query resulting in empty response.
<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

### Before 

![image](https://github.com/EddieHubCommunity/good-first-issue-finder/assets/55016909/b5867f74-f913-40a9-ae6f-a4be74981157)


### After
![image](https://github.com/EddieHubCommunity/good-first-issue-finder/assets/55016909/71b76466-6bd6-46e2-9ef4-47fde85e3c83)
