### PR TITLE
Move unique tags functionality to `filter.svelte`

### DIFF
--- a/src/lib/components/filter.svelte
+++ b/src/lib/components/filter.svelte
@@ -3,7 +3,7 @@
   export let tags: string[];
   export let group: string[];
 
-  $: tags = tags.sort((a, b) => a.localeCompare(b));
+  $: tags = [...new Set(tags)].sort((a, b) => a.localeCompare(b));
 </script>
 
 <form class="mt-8 grid w-full grid-cols-1 md:grid-cols-2 lg:grid-cols-3">

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -48,15 +48,6 @@
     selectedLabels = [];
   };
 
-  $: uniqueTags = $issues.data?.pages?.reduce((acc, page) => {
-    page.labels.forEach((label) => {
-      if (!acc.includes(label)) {
-        acc.push(label);
-      }
-    });
-    return acc;
-  }, [] as string[]);
-
   $: filteredResponse = $issues.data?.pages?.flatMap((page) => {
     return page.edges
       .filter((edge) => {
@@ -96,7 +87,10 @@
     <Search bind:searchTerm={searchString} />
     <div class="flex items-center justify-center">
       <Modal clearFilter={onFilterClear} title="Filters" amount={selectedLabels}>
-        <Filter bind:group={selectedLabels} tags={uniqueTags || []} />
+        <Filter
+          bind:group={selectedLabels}
+          tags={$issues.data?.pages?.flatMap((page) => page.labels) || []}
+        />
       </Modal>
     </div>
   </div>


### PR DESCRIPTION
## Changes proposed

Since `uniqueTags` is not used anywhere, but `app/+page.svelte`. I have moved the unique logic using `new Set()` in `filter.svelte` component.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

It doesn't affect the functionality. 

![image](https://github.com/EddieHubCommunity/good-first-issue-finder/assets/28386721/0527df14-77cc-4aa5-9ee4-5636148b31f8)
