### PR TITLE
bugITwhisperer: playwright skeleton tests steps update

### DIFF
--- a/tests/docs/introduction.spec.ts
+++ b/tests/docs/introduction.spec.ts
@@ -26,6 +26,6 @@ test.fixme(
   'is the left-side menu containing an element with the same name as the page headline',
   async ({ page }) => {
     // navigate to the docs landing page /docs
-    // check if the Introduction element in the left menu is holding the active class
+    // check if both element in the left menu and page header are the same and say 'Introduction'
   },
 );

--- a/tests/docs/introduction.spec.ts
+++ b/tests/docs/introduction.spec.ts
@@ -26,6 +26,6 @@ test.fixme(
   'is the left-side menu containing an element with the same name as the page headline',
   async ({ page }) => {
     // navigate to the docs landing page /docs
-    // check if both element in the left menu and page header are the same and say 'Introduction'
+    // check if both elements in the left menu and page header are the same and say 'Introduction'
   },
 );

--- a/tests/docs/introduction.spec.ts
+++ b/tests/docs/introduction.spec.ts
@@ -1,29 +1,18 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { expect, test } from '@playwright/test';
 
-test('docs header element is active', async ({ page }) => {
+test('Docs header element is active', async ({ page }) => {
   // navigate to the docs landing page /docs
   await page.goto('/docs');
+
   // check if the docs link in the page header is having the active class
   await expect(page.getByRole('link', { name: 'Docs' })).toHaveClass(/active/);
 });
 
-test('Correct Page Heading', async ({ page }) => {
+test('Page Heading is correct', async ({ page }) => {
   // navigate to the docs landing page /docs
   await page.goto('/docs');
+
   // check if the heading contains Introduction
   expect(await page.textContent('h1')).toBe('Introduction');
-});
-
-test.fixme(
-  'is the left-side menu containing an element with the same name as the page headline',
-  async ({ page }) => {
-    // navigate to the docs landing page /docs
-    // check if the Introduction element in the left menu is holding the active class
-  },
-);
-
-test.fixme('is the highlighted item in the left-menu is the correct one', async ({ page }) => {
-  // navigate to the docs landing page /docs
-  // check if the Introduction element in the left menu is holding the active class
 });

--- a/tests/docs/introduction.spec.ts
+++ b/tests/docs/introduction.spec.ts
@@ -16,3 +16,16 @@ test('Page Heading is correct', async ({ page }) => {
   // check if the heading contains Introduction
   expect(await page.textContent('h1')).toBe('Introduction');
 });
+
+test.fixme('is the highlighted item in the left-menu is the correct one', async ({ page }) => {
+  // navigate to the docs landing page /docs
+  // check if the Introduction element in the left menu is highlighted
+});
+
+test.fixme(
+  'is the left-side menu containing an element with the same name as the page headline',
+  async ({ page }) => {
+    // navigate to the docs landing page /docs
+    // check if the Introduction element in the left menu is holding the active class
+  },
+);


### PR DESCRIPTION
## Fixes Issue #378

## Changes proposed
- removed: 2 Playwright test skeletons which are already covered in the tests above and no work is required. Since they are redundant, it's better to delete them not to cause any confusion to anyone reading the code
- added: empty lines between actions to maintain the consistency between `introduction.spec.ts` and `login.spec.ts` files
- adjusted/changed a bit: tests' names for a better readability

1. This 1st skeleton does not require fixing:
```
test.fixme('is the highlighted item in the left-menu is the correct one', async ({ page }) => {
  // navigate to the docs landing page /docs
  // check if the Introduction element in the left menu is holding the active class
});
```

since it's already covered in the 1st test:
```
test('Docs header element is active', async ({ page }) => {
  // navigate to the docs landing page /docs
  await page.goto('/docs');

  // check if the docs link in the page header is having the active class
  await expect(page.getByRole('link', { name: 'Docs' })).toHaveClass(/active/);
});
```

2. Same for the 2nd skeleton:
```
test.fixme(
  'is the left-side menu containing an element with the same name as the page headline',
  async ({ page }) => {
    // navigate to the docs landing page /docs
    // check if the Introduction element in the left menu is holding the active class
  },
);
```
it's been covered by this test:
```
test('Page Heading is correct', async ({ page }) => {
  // navigate to the docs landing page /docs
  await page.goto('/docs');

  // check if the heading contains Introduction
  expect(await page.textContent('h1')).toBe('Introduction');
});
```