### PR TITLE
bugITwhisperer: add new test - intro element highlighted in yellow when hovered over #378

### DIFF
--- a/tests/docs/introduction.spec.ts
+++ b/tests/docs/introduction.spec.ts
@@ -29,3 +29,17 @@ test.fixme(
     // check if both elements in the left menu and page header are the same and say 'Introduction'
   },
 );
+
+test('Introduction element is highlighted as yellow when hovered-over', async ({ page }) => {
+  // navigate to the docs landing page /docs/testing
+  await page.goto('/docs/testing');
+
+  // check the Introduction element on hover has yellow color
+  const introElement = await page.getByRole('link', { name: 'Docs' });
+  await introElement.hover();
+  const introElementAfterHover = await page.getByRole('link', { name: 'Docs' });
+  const introElementColorOnHover = await introElementAfterHover.evaluate((element) =>
+    window.getComputedStyle(element).getPropertyValue('--primary-100'),
+  );
+  await expect(introElementColorOnHover).toEqual('#ffbf00');
+});

--- a/tests/docs/introduction.spec.ts
+++ b/tests/docs/introduction.spec.ts
@@ -39,7 +39,7 @@ test('Introduction element is highlighted as yellow when hovered-over', async ({
   await introElement.hover();
   const introElementAfterHover = await page.getByRole('link', { name: 'Docs' });
   const introElementColorOnHover = await introElementAfterHover.evaluate((element) =>
-    window.getComputedStyle(element).getPropertyValue('--primary-100'),
+    window.getComputedStyle(element).getPropertyValue('--primary-300'),
   );
   await expect(introElementColorOnHover).toEqual('#ffbf00');
 });


### PR DESCRIPTION
## Fixes Issue https://github.com/EddieHubCommunity/good-first-issue-finder/issues/378

## Changes proposed
* add a new test that checks whether introduction element (1st element from left-menu) gets highlighted as yellow when hovered over
 
```
test('Introduction element is highlighted as yellow when hovered-over', async ({ page }) => {
  // navigate to the docs landing page /docs/testing
  await page.goto('/docs/testing');

  // check the Introduction element on hover has yellow color
  const introElement = await page.getByRole('link', { name: 'Docs' });
  await introElement.hover();
  const introElementAfterHover = await page.getByRole('link', { name: 'Docs' });
  const introElementColorOnHover = await introElementAfterHover.evaluate((element) =>
    window.getComputedStyle(element).getPropertyValue('--primary-300'),
  );
  await expect(introElementColorOnHover).toEqual('#ffbf00');
});
```