### PR TITLE
Fixes #408 GitHub footer icon colour fixed

### DIFF
--- a/src/lib/components/footer.svelte
+++ b/src/lib/components/footer.svelte
@@ -24,7 +24,7 @@
           data-test-id="github-btn"
           target="_blank"
           rel="noreferrer"
-          class="transition duration-200 hover:text-[#333333] active:text-primary-100 dark:hover:text-[#fafafa]"
+          class="transition duration-200 hover:text-[#ffffff] active:text-primary-100"
           href="http://github.eddiehub.org"
           aria-label="Github"><i class="fa-brands fa-github fa-xl" title="Github" /></a
         >

--- a/src/lib/components/index/github-card.svelte
+++ b/src/lib/components/index/github-card.svelte
@@ -29,7 +29,7 @@
 
 <style lang="postcss">
   .card:hover::before {
-    @apply absolute -z-10 h-[500px] w-[100px] bg-[#000000];
+    @apply absolute -z-10 h-[500px] w-[100px] bg-[#fff];
     content: '';
     animation: animate-circle 5s linear infinite;
   }


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
Closes #408 

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->
Changed the colour of github icon in footer when active from white to EddieHubCommunity orange
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->
Before 
![image](https://github.com/EddieHubCommunity/good-first-issue-finder/assets/85438531/23e5bcaf-e910-4338-8012-c4ab1434a269)

After
![image](https://github.com/EddieHubCommunity/good-first-issue-finder/assets/85438531/2ca7f259-e917-4262-9085-877fe23e04fb)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->