### PR TITLE
Corrected Github footer icon active color

### DIFF
--- a/src/lib/components/footer.svelte
+++ b/src/lib/components/footer.svelte
@@ -24,7 +24,7 @@
           data-test-id="github-btn"
           target="_blank"
           rel="noreferrer"
-          class="transition duration-200 hover:text-[#333333] active:text-primary-100 dark:hover:text-[#fafafa]"
+          class="transition duration-200 hover:text-[#333333] active:text-primary-100 active:text-primary-100"
           href="http://github.eddiehub.org"
           aria-label="Github"><i class="fa-brands fa-github fa-xl" title="Github" /></a
         >


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

#408 ( Corrected Github footer icon active color )

## Screenshots

![Screenshot 2024-09-01 203028](https://github.com/user-attachments/assets/c02667ca-71f6-46e2-9fad-8c36f4112cb2)
